### PR TITLE
Add reverse/pull mode, granular preserve flags, per-host options

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -81,14 +81,20 @@ decodeEnrichedOptions :: Map Text Value -> Parser (FilePath, RsyncOptions)
 decodeEnrichedOptions m =
   parseM (m ^. at "Path") >>= \case
     Nothing -> fail "Missing value for Path"
-    Just path ->
+    Just path -> do
+      preserveAll <- fromMaybe False <$> parseM (m ^. at "PreserveAttrs")
       (path,)
         <$> ( RsyncOptions
                 <$> parseM (m ^. at "Filters")
                 <*> parseM (m ^. at "ExtraFilters")
                 <*> (fromMaybe False <$> parseM (m ^. at "NoBasicOptions"))
                 <*> (fromMaybe False <$> parseM (m ^. at "NoDelete"))
-                <*> (fromMaybe False <$> parseM (m ^. at "PreserveAttrs"))
+                <*> (fromMaybe preserveAll <$> parseM (m ^. at "PreserveACLs"))
+                <*> (fromMaybe preserveAll <$> parseM (m ^. at "PreserveXattrs"))
+                <*> (fromMaybe preserveAll <$> parseM (m ^. at "PreserveAtimes"))
+                <*> (fromMaybe preserveAll <$> parseM (m ^. at "PreserveCrtimes"))
+                <*> (fromMaybe preserveAll <$> parseM (m ^. at "PreserveHardLinks"))
+                <*> (fromMaybe preserveAll <$> parseM (m ^. at "PreserveExecutability"))
                 <*> (fromMaybe False <$> parseM (m ^. at "ProtectTopLevel"))
                 <*> parseM (m ^. at "Options")
                 <*> parseM (m ^. at "ReceiveFrom")
@@ -459,7 +465,12 @@ invokeRsync bnd src roDest host dest = do
   rsyncArguments opts args =
     ["-a" | not (roDest ^. rsyncNoBasicOptions)]
       <> ["--delete" | not (roDest ^. rsyncNoDelete)]
-      <> ["-AXUNHE" | roDest ^. rsyncPreserveAttrs]
+      <> ["-A" | roDest ^. rsyncPreserveACLs]
+      <> ["-X" | roDest ^. rsyncPreserveXattrs]
+      <> ["-U" | roDest ^. rsyncPreserveAtimes]
+      <> ["-N" | roDest ^. rsyncPreserveCrtimes]
+      <> ["-H" | roDest ^. rsyncPreserveHardLinks]
+      <> ["-E" | roDest ^. rsyncPreserveExecutability]
       <> ["-n" | opts ^. optsDryRun]
       <> ( if opts ^. optsVerbose
              then ["-v"]

--- a/Main.hs
+++ b/Main.hs
@@ -66,6 +66,9 @@ import Text.Show.Pretty (ppShow)
 data TransferStatus = TransferSuccess | TransferWarning | TransferError
   deriving (Show, Eq, Ord)
 
+data SyncDirection = Push | Pull
+  deriving (Show, Eq, Ord)
+
 data Fileset = Fileset
   { _filesetName :: Text
   , _filesetClasses :: Maybe [Text]
@@ -215,10 +218,16 @@ data Binding = Binding
   , _bindingTargetHost :: HostRef
   , _bindingTargetPath :: FilePath
   , _bindingRsyncOpts :: RsyncOptions
+  , _bindingDirection :: SyncDirection
   }
   deriving (Show, Eq)
 
 makeLenses ''Binding
+
+bindingRemoteHost :: Binding -> HostRef
+bindingRemoteHost bnd = case bnd ^. bindingDirection of
+  Push -> bnd ^. bindingTargetHost
+  Pull -> bnd ^. bindingSourceHost
 
 isLocal :: Binding -> Bool
 isLocal bnd =
@@ -228,7 +237,9 @@ isLocal bnd =
 remoteHost :: Binding -> Maybe Host
 remoteHost bnd
   | isLocal bnd = Nothing
-  | otherwise = Just (hostFromRef (bnd ^. bindingTargetHost))
+  | otherwise = case bnd ^. bindingDirection of
+      Push -> Just (hostFromRef (bnd ^. bindingTargetHost))
+      Pull -> Just (hostFromRef (bnd ^. bindingSourceHost))
 
 type App a = ReaderT Options IO a
 
@@ -258,19 +269,35 @@ processBindings = do
   case opts ^. optsCliArgs of
     host : hosts@(_ : _) -> liftIO do
       fsets <- traverse expandFilesetPaths =<< readFilesets opts
-      let here = parseHostRef opts (pack host)
+      -- Determine direction: --reverse flag or auto-detect from hostname
+      localHostname <-
+        T.toLower . T.takeWhile (/= '.') . T.strip . pack
+          <$> readProcess "hostname" ["-s"] ""
+      let hereRef = parseHostRef opts (pack host)
+          allHostRefs = map (parseHostRef opts . pack) hosts
+          resolvedName ref =
+            T.toLower $ T.takeWhile (/= '.') $ fst (ref ^. hostRefActualHost)
+          -- Auto-detect: if first arg is not local, find the local host
+          -- among the remaining args and treat as reverse (pull) mode
+          (here, remoteRefs, pullMode)
+            | opts ^. optsReverse = (hereRef, allHostRefs, True)
+            | resolvedName hereRef /= localHostname =
+                case filter (\r -> resolvedName r == localHostname) allHostRefs of
+                  (localRef : _) ->
+                    (localRef, hereRef : filter (/= localRef) allHostRefs, True)
+                  [] -> (hereRef, allHostRefs, False)
+            | otherwise = (hereRef, allHostRefs, False)
           bindings =
-            relevantBindings
-              opts
-              here
-              fsets
-              (map (parseHostRef opts . pack) hosts)
+            relevantBindings opts here fsets remoteRefs pullMode
+      when pullMode $
+        debug' "Reverse mode: pulling from remote hosts"
       debug' $
         "Local host "
           <> fst (here ^. hostRefActualHost)
           <> " with "
           <> tshow (snd (here ^. hostRefActualHost))
-          <> " sending jobs"
+          <> (if pullMode then " receiving" else " sending")
+          <> " jobs"
       hereSlots <- newQSem (snd (here ^. hostRefActualHost))
       thereSlotsAll <- forM (M.keys bindings) $ \there -> do
         debug' $
@@ -316,11 +343,17 @@ processBindings = do
 
   applyBinding :: Binding -> App TransferStatus
   applyBinding bnd = do
-    log' $
-      "Sending "
-        <> (bnd ^. bindingFileset . filesetName)
-        <> " → "
-        <> (bnd ^. bindingTargetHost . hostRefLogicalName)
+    log' $ case bnd ^. bindingDirection of
+      Push ->
+        "Sending "
+          <> (bnd ^. bindingFileset . filesetName)
+          <> " → "
+          <> (bnd ^. bindingTargetHost . hostRefLogicalName)
+      Pull ->
+        "Receiving "
+          <> (bnd ^. bindingFileset . filesetName)
+          <> " ← "
+          <> (bnd ^. bindingSourceHost . hostRefLogicalName)
     debug' $ pack (ppShow bnd)
     syncStores
       bnd
@@ -333,43 +366,83 @@ processBindings = do
     HostRef ->
     Map Text Fileset ->
     [HostRef] ->
+    Bool ->
     Map HostRef [Binding]
-  relevantBindings opts here fsets hosts =
+  relevantBindings opts here fsets hosts pullMode =
     M.map
       (sortOn (^. bindingFileset . filesetPriority))
-      (collect (^. bindingTargetHost) bindings)
+      (collect bindingRemoteHost bindings)
    where
     bindings :: [Binding]
     bindings = do
       fset <- M.elems fsets
       there <- hosts
-      maybeToList do
-        (src, _) <- fset ^. filesetStores . at (here ^. hostRefLogicalName)
-        (dest, destOpts) <- fset ^. filesetStores . at (there ^. hostRefLogicalName)
-        guard $
-          not
-            ( maybe
-                False
-                (not . (here ^. hostRefLogicalName `elem`))
-                (destOpts ^. rsyncReceiveFrom)
-            )
-        let !srcPath = interpolatePath (here ^. hostRefVariables) src
-            !destPath = interpolatePath (there ^. hostRefVariables) dest
-            binding =
-              Binding
-                { _bindingFileset = fset
-                , _bindingSourceHost = here
-                , _bindingSourcePath = srcPath
-                , _bindingTargetHost = there
-                , _bindingTargetPath = destPath
-                , _bindingRsyncOpts =
-                    case opts ^. optsRsyncOpts <> fset ^. filesetCommon of
-                      Nothing -> destOpts
-                      Just common -> common <> destOpts
-                }
-        guard $ isMatching binding
-        guard $ destOpts ^. rsyncActive
-        pure binding
+      maybeToList $
+        if pullMode
+          then buildPullBinding fset there
+          else buildPushBinding fset there
+
+    buildPushBinding :: Fileset -> HostRef -> Maybe Binding
+    buildPushBinding fset there = do
+      (src, _) <- fset ^. filesetStores . at (here ^. hostRefLogicalName)
+      (dest, destOpts) <- fset ^. filesetStores . at (there ^. hostRefLogicalName)
+      guard $
+        not
+          ( maybe
+              False
+              (not . (here ^. hostRefLogicalName `elem`))
+              (destOpts ^. rsyncReceiveFrom)
+          )
+      let !srcPath = interpolatePath (here ^. hostRefVariables) src
+          !destPath = interpolatePath (there ^. hostRefVariables) dest
+          binding =
+            Binding
+              { _bindingFileset = fset
+              , _bindingSourceHost = here
+              , _bindingSourcePath = srcPath
+              , _bindingTargetHost = there
+              , _bindingTargetPath = destPath
+              , _bindingRsyncOpts =
+                  case opts ^. optsRsyncOpts <> fset ^. filesetCommon of
+                    Nothing -> destOpts
+                    Just common -> common <> destOpts
+              , _bindingDirection = Push
+              }
+      guard $ isMatching binding
+      guard $ destOpts ^. rsyncActive
+      pure binding
+
+    buildPullBinding :: Fileset -> HostRef -> Maybe Binding
+    buildPullBinding fset there = do
+      (srcPath0, srcOpts) <- fset ^. filesetStores . at (there ^. hostRefLogicalName)
+      (destPath0, destOpts) <- fset ^. filesetStores . at (here ^. hostRefLogicalName)
+      -- ReceiveFrom: does local store allow receiving from remote?
+      guard $
+        not
+          ( maybe
+              False
+              (not . (there ^. hostRefLogicalName `elem`))
+              (destOpts ^. rsyncReceiveFrom)
+          )
+      let !srcPath = interpolatePath (there ^. hostRefVariables) srcPath0
+          !destPath = interpolatePath (here ^. hostRefVariables) destPath0
+          binding =
+            Binding
+              { _bindingFileset = fset
+              , _bindingSourceHost = there
+              , _bindingSourcePath = srcPath
+              , _bindingTargetHost = here
+              , _bindingTargetPath = destPath
+              , _bindingRsyncOpts =
+                  case opts ^. optsRsyncOpts <> fset ^. filesetCommon of
+                    Nothing -> destOpts
+                    Just common -> common <> destOpts
+              , _bindingDirection = Pull
+              }
+      guard $ isMatching binding
+      guard $ srcOpts ^. rsyncActive
+      guard $ destOpts ^. rsyncActive
+      pure binding
 
     isMatching :: Binding -> Bool
     isMatching bnd =
@@ -415,15 +488,23 @@ checkDirectory bnd path True =
 
 syncStores :: Binding -> FilePath -> FilePath -> RsyncOptions -> App TransferStatus
 syncStores bnd src dest roDest = do
-  exists <-
-    (&&)
-      <$> checkDirectory bnd l False
-      <*> checkDirectory bnd r True
+  exists <- case bnd ^. bindingDirection of
+    Push ->
+      (&&)
+        <$> checkDirectory bnd l False
+        <*> checkDirectory bnd r True
+    Pull ->
+      (&&)
+        <$> checkDirectory bnd l True
+        <*> checkDirectory bnd r False
   if exists
     then invokeRsync bnd l roDest (remoteHost bnd) r
     else liftIO do
-      warn $ "Either local directory missing: " <> pack l
-      warn $ "OR remote directory missing: " <> pack r
+      let (localDir, remoteDir) = case bnd ^. bindingDirection of
+            Push -> (l, r)
+            Pull -> (r, l)
+      warn $ "Either local directory missing: " <> pack localDir
+      warn $ "OR remote directory missing: " <> pack remoteDir
       pure TransferError
  where
   (asDirectory -> l) = src
@@ -441,7 +522,7 @@ invokeRsync bnd src roDest host dest = do
   withProtected $ \args1 ->
     withFilters "Filters" (combineFilters (roDest ^. rsyncFilters) (roDest ^. rsyncExtraFilters)) $ \args2 ->
       doRsync
-        ( bnd ^. bindingTargetHost . hostRefLogicalName
+        ( bindingRemoteHost bnd ^. hostRefLogicalName
             <> "/"
             <> bnd ^. bindingFileset . filesetName
         )
@@ -478,11 +559,19 @@ invokeRsync bnd src roDest host dest = do
          )
       <> args
       <> fromMaybe [] (roDest ^. rsyncOptions)
-      <> [ pack src
-         , case host ^? _Just . hostName of
-             Nothing -> pack dest
-             Just h -> h <> ":" <> T.intercalate "\\ " (T.words (pack dest))
-         ]
+      <> case bnd ^. bindingDirection of
+           Push ->
+             [ pack src
+             , case host ^? _Just . hostName of
+                 Nothing -> pack dest
+                 Just h -> h <> ":" <> T.intercalate "\\ " (T.words (pack dest))
+             ]
+           Pull ->
+             [ case host ^? _Just . hostName of
+                 Nothing -> pack src
+                 Just h -> h <> ":" <> T.intercalate "\\ " (T.words (pack src))
+             , pack dest
+             ]
 
 doRsync :: Text -> [Text] -> App TransferStatus
 doRsync label args = do

--- a/Main.hs
+++ b/Main.hs
@@ -162,6 +162,7 @@ parseHostRef opts name =
                 { _hostRefLogicalName = baseName
                 , _hostRefActualHost = (actualName, finalJobs)
                 , _hostRefVariables = alias ^. aliasVariables
+                , _hostRefOptions = alias ^. aliasOptions
                 }
         Nothing ->
           let host = parseHost baseName
@@ -170,6 +171,7 @@ parseHostRef opts name =
                 { _hostRefLogicalName = baseName
                 , _hostRefActualHost = (baseName, finalJobs)
                 , _hostRefVariables = M.empty
+                , _hostRefOptions = Nothing
                 }
 
 {- | Interpolate all $variable references in a path using the provided variable map.
@@ -559,6 +561,7 @@ invokeRsync bnd src roDest host dest = do
          )
       <> args
       <> fromMaybe [] (roDest ^. rsyncOptions)
+      <> fromMaybe [] (bindingRemoteHost bnd ^. hostRefOptions)
       <> case bnd ^. bindingDirection of
            Push ->
              [ pack src

--- a/src/Pushme/Options.hs
+++ b/src/Pushme/Options.hs
@@ -143,6 +143,7 @@ data Options = Options
   , _optsSiUnits :: Bool
   , _optsVerbose :: Bool
   , _optsNoColor :: Bool
+  , _optsReverse :: Bool
   , _optsRsyncOpts :: Maybe RsyncOptions
   , _optsAliases :: Map Text Alias
   , _optsCliArgs :: [String]
@@ -167,14 +168,15 @@ instance FromJSON Options where
       <*> v .:? "SIUnits" .!= False
       <*> v .:? "Verbose" .!= False
       <*> v .:? "NoColor" .!= False
+      <*> v .:? "Reverse" .!= False
       <*> v .:? "GlobalOptions"
       <*> pure aliasMapWithNames
       <*> pure []
   parseJSON _ = errorL "Error parsing Options"
 
 instance Semigroup Options where
-  Options _a1 b1 c1 d1 e1 f1 g1 h1 i1 j1
-    <> Options a2 b2 c2 d2 e2 f2 g2 h2 i2 j2 =
+  Options _a1 b1 c1 d1 e1 f1 g1 g1r h1 i1 j1
+    <> Options a2 b2 c2 d2 e2 f2 g2 g2r h2 i2 j2 =
       Options
         a2
         (b2 || b1)
@@ -183,6 +185,7 @@ instance Semigroup Options where
         (e2 || e1)
         (f2 || f1)
         (g2 || g1)
+        (g2r || g1r)
         (h2 <> h1)
         (i2 <> i1) -- Right-biased merge: right Map wins on key conflicts
         (j2 <|> j1)
@@ -234,6 +237,11 @@ pushmeOpts =
     <*> switch
       ( long "no-color"
           <> help "Do not use ANSI colors in report output"
+      )
+    <*> switch
+      ( short 'R'
+          <> long "reverse"
+          <> help "Pull from remote hosts instead of pushing to them"
       )
     <*> optional
       ( (\filters noBasic noDelete preserveAll protectTop opts ->

--- a/src/Pushme/Options.hs
+++ b/src/Pushme/Options.hs
@@ -96,6 +96,7 @@ data Alias = Alias
   , _aliasHost :: Text
   , _aliasMaxJobs :: Maybe Int
   , _aliasVariables :: Map Text Text
+  , _aliasOptions :: Maybe [Text]
   }
   deriving (Show, Eq)
 
@@ -116,6 +117,7 @@ instance FromJSON Alias where
     Alias "" host -- Name will be filled in from the Map key
       <$> v .:? "MaxJobs"
       <*> pure finalVariables
+      <*> v .:? "Options"
    where
     addContext msg = "Error parsing Alias: " ++ msg
   parseJSON _ = errorL "Error parsing Alias"
@@ -130,6 +132,7 @@ data HostRef = HostRef
   { _hostRefLogicalName :: Text
   , _hostRefActualHost :: (Text, Int) -- (hostName, maxJobs) - avoiding circular dependency
   , _hostRefVariables :: Map Text Text
+  , _hostRefOptions :: Maybe [Text] -- Per-host rsync options from alias
   }
   deriving (Show, Eq, Ord)
 

--- a/src/Pushme/Options.hs
+++ b/src/Pushme/Options.hs
@@ -30,7 +30,12 @@ data RsyncOptions = RsyncOptions
   , _rsyncExtraFilters :: Maybe Text
   , _rsyncNoBasicOptions :: Bool
   , _rsyncNoDelete :: Bool
-  , _rsyncPreserveAttrs :: Bool
+  , _rsyncPreserveACLs :: Bool -- -A
+  , _rsyncPreserveXattrs :: Bool -- -X
+  , _rsyncPreserveAtimes :: Bool -- -U
+  , _rsyncPreserveCrtimes :: Bool -- -N
+  , _rsyncPreserveHardLinks :: Bool -- -H
+  , _rsyncPreserveExecutability :: Bool -- -E
   , _rsyncProtectTopLevel :: Bool
   , _rsyncOptions :: Maybe [Text]
   , _rsyncReceiveFrom :: Maybe [Text]
@@ -39,13 +44,19 @@ data RsyncOptions = RsyncOptions
   deriving (Show, Eq)
 
 instance FromJSON RsyncOptions where
-  parseJSON (Object v) =
+  parseJSON (Object v) = do
+    preserveAll <- v .:? "PreserveAttrs" .!= False
     RsyncOptions
       <$> v .:? "Filters"
       <*> v .:? "ExtraFilters"
       <*> v .:? "NoBasicOptions" .!= False
       <*> v .:? "NoDelete" .!= False
-      <*> v .:? "PreserveAttrs" .!= False
+      <*> v .:? "PreserveACLs" .!= preserveAll
+      <*> v .:? "PreserveXattrs" .!= preserveAll
+      <*> v .:? "PreserveAtimes" .!= preserveAll
+      <*> v .:? "PreserveCrtimes" .!= preserveAll
+      <*> v .:? "PreserveHardLinks" .!= preserveAll
+      <*> v .:? "PreserveExecutability" .!= preserveAll
       <*> v .:? "ProtectTopLevel" .!= False
       <*> v .:? "Options"
       <*> v .:? "ReceiveFrom"
@@ -53,18 +64,23 @@ instance FromJSON RsyncOptions where
   parseJSON _ = errorL "Error parsing Rsync"
 
 instance Semigroup RsyncOptions where
-  RsyncOptions a1 b1 c1 d1 e1 f1 g1 h1 i1
-    <> RsyncOptions a2 b2 c2 d2 e2 f2 g2 h2 i2 =
+  RsyncOptions a1 b1 c1 d1 e1 f1 g1 h1 i1 j1 k1 l1 m1 n1
+    <> RsyncOptions a2 b2 c2 d2 e2 f2 g2 h2 i2 j2 k2 l2 m2 n2 =
       RsyncOptions
-        (a2 <|> a1)
-        (combineFilters b1 b2)
-        (c2 || c1)
-        (d2 || d1)
-        (e2 || e1)
-        (f2 || f1)
-        (g2 <|> g1)
-        (h2 <|> h1)
-        (i2 && i1)
+        (a2 <|> a1) -- Filters
+        (combineFilters b1 b2) -- ExtraFilters
+        (c2 || c1) -- NoBasicOptions
+        (d2 || d1) -- NoDelete
+        (e2 || e1) -- PreserveACLs
+        (f2 || f1) -- PreserveXattrs
+        (g2 || g1) -- PreserveAtimes
+        (h2 || h1) -- PreserveCrtimes
+        (i2 || i1) -- PreserveHardLinks
+        (j2 || j1) -- PreserveExecutability
+        (k2 || k1) -- ProtectTopLevel
+        (l2 <|> l1) -- Options
+        (m2 <|> m1) -- ReceiveFrom
+        (n2 && n1) -- Active
 
 combineFilters :: Maybe Text -> Maybe Text -> Maybe Text
 combineFilters Nothing Nothing = Nothing
@@ -220,14 +236,16 @@ pushmeOpts =
           <> help "Do not use ANSI colors in report output"
       )
     <*> optional
-      ( RsyncOptions
+      ( (\filters noBasic noDelete preserveAll protectTop opts ->
+           RsyncOptions filters Nothing noBasic noDelete
+             preserveAll preserveAll preserveAll preserveAll preserveAll preserveAll
+             protectTop opts Nothing True)
           <$> optional
             ( strOption
                 ( long "rsync-filters"
                     <> help "rsync filters to pass using --include-from"
                 )
             )
-          <*> pure Nothing
           <*> switch
             ( long "rsync-no-basic-options"
                 <> help "Do not pass -a (and possibly other basic options)"
@@ -238,7 +256,7 @@ pushmeOpts =
             )
           <*> switch
             ( long "rsync-preserve-attrs"
-                <> help "Preserve all attributes (i.e., pass -AXUNHE)"
+                <> help "Preserve all attributes (-AXUNHE)"
             )
           <*> switch
             ( long "rsync-protect-top-level"
@@ -251,8 +269,6 @@ pushmeOpts =
                     <> help "Space-separated list of options to pass to rsync"
                 )
             )
-          <*> pure Nothing
-          <*> pure True
       )
     <*> pure M.empty -- Aliases come from config file, not CLI
     <*> many (argument (eitherReader Right) (metavar "ARGS"))

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -48,7 +48,12 @@ genRsyncOptions =
     <*> genMaybeText
     <*> Gen.bool
     <*> Gen.bool
-    <*> Gen.bool
+    <*> Gen.bool -- PreserveACLs
+    <*> Gen.bool -- PreserveXattrs
+    <*> Gen.bool -- PreserveAtimes
+    <*> Gen.bool -- PreserveCrtimes
+    <*> Gen.bool -- PreserveHardLinks
+    <*> Gen.bool -- PreserveExecutability
     <*> Gen.bool
     <*> genMaybeTextList
     <*> genMaybeTextList


### PR DESCRIPTION
## Summary

- **Split `PreserveAttrs` into individual flags**: Replace the monolithic `-AXUNHE` with six individual flags (`PreserveACLs`, `PreserveXattrs`, `PreserveAtimes`, `PreserveCrtimes`, `PreserveHardLinks`, `PreserveExecutability`). `PreserveAttrs: true` remains as a shorthand that sets all six, with individual flags available to override. This fixes rsync failures when syncing with Linux hosts whose rsync lacks crtimes support.

- **Add `--reverse` / `-R` flag for pull mode**: Support pulling files from remote hosts instead of only pushing. Three trigger modes: explicit `--reverse` flag, explicit `-R` short flag, and auto-detection when the first CLI arg doesn't match the local hostname.

- **Add per-host rsync options**: Aliases can now specify `Options` (list of rsync flags) that apply to every transfer involving that host, enabling `--rsync-path` for hosts with non-standard rsync locations.

## Test plan

- [x] All existing property tests pass (Semigroup associativity, combineFilters)
- [x] Clean build with no warnings
- [ ] Manual test: `pushme hera andoria` (push, existing behavior)
- [ ] Manual test: `pushme --reverse hera andoria` (pull from andoria)
- [ ] Manual test: `pushme andoria hera` (auto-detected pull)
- [ ] Verify `PreserveCrtimes: false` in fileset Common prevents `-N` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)